### PR TITLE
Options don't work when not using the new keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var crypto = require('crypto');
 
 function EncryptedField(Sequelize, key, opt) {
     if (!(this instanceof EncryptedField)) {
-        return new EncryptedField(Sequelize, key);
+        return new EncryptedField(Sequelize, key, opt);
     }
 
     var self = this;


### PR DESCRIPTION
Great project, thanks for sharing.

Just a quick bug & fix... the code checks for usage without the `new` keyword, and wraps it for you, which is handy, but in that codepath doesn't pass through the `opt` argument so all the options get ignored.