### PR TITLE
Add option to specify what encoding to use in the database field

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ function EncryptedField(Sequelize, key, opt) {
     var self = this;
     self.key = new Buffer(key, 'hex');
     self.Sequelize = Sequelize;
-    
+
     opt = opt || {};
     self._algorithm = opt.algorithm || 'aes-256-cbc';
     self._iv_length = opt.iv_length || 16;
-    self._db_encoding = opt.db_encoding || undefined;
+    self._db_encoding = opt.db_encoding || 'binary';
 };
 
 EncryptedField.prototype.vault = function(name) {
@@ -40,8 +40,8 @@ EncryptedField.prototype.vault = function(name) {
             var cipher = crypto.createCipheriv(self._algorithm, self.key, new_iv);
 
             var enc_final = Buffer.concat([
-                cipher.update(new_iv),
-                cipher.update(JSON.stringify(value)),
+                new_iv,
+                cipher.update(JSON.stringify(value),'utf8'),
                 cipher.final()
             ]);
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var crypto = require('crypto');
 
 function EncryptedField(Sequelize, key, opt) {
     if (!(this instanceof EncryptedField)) {
-        return new EncryptedField(Sequelize, key);
+        return new EncryptedField(Sequelize, key, opt);
     }
 
     var self = this;


### PR DESCRIPTION
I've been having some trouble retrieving cleartext from this module when persisting to Postgres. Everything seems to work in isolation but when it runs together I'm getting some kind of automatic transcoding happening. Text appears in the database in what looks like hex, but isn't quite and then errors when I try to decrypt it. The problem seems to be in Postgres' handling of binary blobs but I haven't managed to pin it down.

To work around the problem I've added an option to specify what encoding to use in `sequelize-encrypted`, so that I can persist the ciphertext as `base64` or `hex` which sidesteps the problem.

    var encryptedFields = require('sequelize-encrypted')(
        sequelize,
        key, 
        {
            db_encoding : 'base64'    //optional
        }
    );

I've made the option optional, so this should be a non-breaking change with respect to the arguments passed when you instantiate it... but couldn't find any documentation for `cypher.end()` and `cypher.read()` so used `cypher.final()` which seems to do the same job. I'm a bit concerned that I can't find documenation for those method calls though, I looked at node `0.12` all the way back to `0.4`. Normally I would have left it alone and kept the diff line count down but couldn't find the docs for those calls. Expecting you to tell me I've missed something obvious.