### PR TITLE
Allow use of other property names than 'encrypted'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,24 @@ Encrypted fields for Sequelize ORM
 
 ```js
 var Sequelize = require('sequelize')
-var EncryptedField = require('sequelize-encrypted');
+var enc = require('sequelize-encrypted');
 
-// secret key should be 32 bytes hex encoded (64 characters)
-var key = process.env.SECRET_KEY_HERE;
-
-var enc_fields = EncryptedField(Sequelize, key);
-
-var User = sequelize.define('user', {
+var User = sequelize.define('user', enc.enVault({
     name: Sequelize.STRING,
-    encrypted: enc_fields.vault('encrypted'),
-
+    vault: {
+       type: enc.VAULT,
+       // secret key should be 32 bytes hex encoded (64 characters)
+       key: process.env.SECRET_KEY,
+       // field: 'legacy_blob_field_name',
+       // algorithm: 'aes-256-cbc,
+       // ivLength: 16
+    },
     // encrypted virtual fields
-    private_1: enc_fields.field('private_1'),
-    private_2: enc_fields.field('private_2')
-})
+    private_1: enc.FIELD,
+    private_2: {
+       type: enc.FIELD
+    }
+}));
 
 var user = User.build();
 user.private_1 = 'test';
@@ -26,11 +29,9 @@ user.private_1 = 'test';
 
 ## How it works
 
-The `safe` returns a sequelize BLOB field configured with getters/setters for decrypting and encrypting data. Encrypted JSON encodes the value you set and then encrypts this value before storing in the database.
+The `withVault` adds a sequelize BLOB field to the model configured with getters/setters for decrypting and encrypting data. Encrypted JSON encodes the value you set and then encrypts this value before storing in the database.
 
-Additionally, there are `.field` methods which return sequelize VIRTUAL fields that provide access to specific fields in the encrypted vault. It is recommended that these are used to get/set values versus using the encrypted field directly.
-
-When calling `.vault` or `.field` you must specify the field name. This cannot be auto-detected by the module.
+Additionally, is a `FIELD` type that is replaced with a sequelize VIRTUAL field that provides access to specific fields in the encrypted vault. It is recommended that these are used to get/set values versus using the encrypted field directly.
 
 ## Generating a key
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var crypto = require('crypto');
 
 function EncryptedField(Sequelize, key, opt) {
@@ -12,7 +13,7 @@ function EncryptedField(Sequelize, key, opt) {
     opt = opt || {};
     self._algorithm = opt.algorithm || 'aes-256-cbc';
     self._iv_length = opt.iv_length || 16;
-};
+}
 
 EncryptedField.prototype.vault = function(name) {
     var self = this;
@@ -21,6 +22,7 @@ EncryptedField.prototype.vault = function(name) {
         type: self.Sequelize.BLOB,
         get: function() {
             var previous = this.getDataValue(name);
+
             if (!previous) {
                 return {};
             }
@@ -44,10 +46,10 @@ EncryptedField.prototype.vault = function(name) {
             var enc_final = Buffer.concat([new_iv, cipher.read()]);
             var previous = this.setDataValue(name, enc_final);
         }
-    }
+    };
 };
 
-EncryptedField.prototype.field = function(name) {
+EncryptedField.prototype.fieldInVault = function(name, vaultName) {
     var self = this;
 
     return {
@@ -55,15 +57,15 @@ EncryptedField.prototype.field = function(name) {
         set: function set_encrypted(val) {
             // use `this` not self because we need to reference the sequelize instance
             // not our EncryptedField instance
-            var encrypted = this.encrypted;
+            var encrypted = this[vaultName];
             encrypted[name] = val;
-            this.encrypted = encrypted;
+            this[vaultName] = encrypted;
         },
         get: function get_encrypted() {
-            var encrypted = this.encrypted;
+            var encrypted = this[vaultName];
             return encrypted[name];
         }
-    }
+    };
 };
 
 module.exports = EncryptedField;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-encrypted",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "encrypted sequelize fields",
   "main": "index.js",
   "scripts": {
@@ -23,5 +23,8 @@
   "devDependencies": {
     "mocha": "2.0.1",
     "sequelize": "2.0.0-rc2"
+  },
+  "dependencies": {
+    "lodash": "^3.10.1"
   }
 }


### PR DESCRIPTION
The way this was written, the vault can only be named 'encrypted' and
there can only be one vault per entity. This allows multiple
arbitrarily-named vaults with different keys.

This does change the api for constructing fields from simply field(name)
to fieldInVault(name, vaultName).
