### PR TITLE
add feature to specify encrypted field name

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+    "plugins": [
+        "transform-async-to-generator",
+        "transform-es2015-modules-commonjs",
+    ]
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+node_js:
+  - "6"
+  - "4"
+
+addons:
+  hosts:
+    - db
+
+services:
+  - postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM mhart/alpine-node:6.2.2
+
+WORKDIR /app
+ADD package.json /app/
+RUN npm install
+
+ADD . /app/
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Encrypted fields for Sequelize ORM
 
 ```js
-var Sequelize = require('sequelize')
+var Sequelize = require('sequelize');
 var EncryptedField = require('sequelize-encrypted');
 
 // secret key should be 32 bytes hex encoded (64 characters)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+    db:
+        image: postgres:9.5.3
+
+    app:
+        build: .
+        links:
+            - db
+        command: sleep infinity
+        volumes:
+            - .:/app
+            - /app/node_modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "encrypted sequelize fields",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --ui qunit --reporter list --check-leaks --bail -- test/index.js"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -21,7 +21,13 @@
   },
   "homepage": "https://github.com/defunctzombie/sequelize-encrypted",
   "devDependencies": {
+    "babel-plugin-transform-async-to-generator": "6.8.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.10.3",
+    "babel-polyfill": "6.9.1",
+    "babel-preset-es2015": "6.9.0",
+    "babel-register": "6.9.0",
     "mocha": "2.0.1",
-    "sequelize": "2.0.0-rc2"
+    "pg": "6.0.1",
+    "sequelize": "3.23.4"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,61 @@
+import assert from 'assert';
+import Sequelize from 'sequelize';
+import EncryptedField from '../';
+
+const sequelize = new Sequelize('postgres://postgres@db:5432/postgres');
+
+const key1 = 'a593e7f567d01031d153b5af6d9a25766b95926cff91c6be3438c7f7ac37230e';
+const key2 = 'a593e7f567d01031d153b5af6d9a25766b95926cff91c6be3438c7f7ac37230f';
+
+const v1 = EncryptedField(Sequelize, key1);
+const v2 = EncryptedField(Sequelize, key2);
+
+describe('sequelize-encrypted', () => {
+
+    const User = sequelize.define('user', {
+        name: Sequelize.STRING,
+        encrypted: v1.vault('encrypted'),
+        another_encrypted: v2.vault('another_encrypted'),
+
+        // encrypted virtual fields
+        private_1: v1.field('private_1'),
+        private_2: v2.field('private_2'),
+    });
+
+    before('create models', async () => {
+        await User.sync({force: true});
+    });
+
+    it('should save an encrypted field', async () => {
+        const user = User.build();
+        user.private_1 = 'test';
+
+        await user.save();
+        const found = await User.findById(user.id);
+        assert.equal(found.private_1, user.private_1);
+    });
+
+    it('should support multiple encrypted fields', async() => {
+        const user = User.build();
+        user.private_1 = 'baz';
+        user.private_2 = 'foobar';
+        await user.save();
+
+        const vault = EncryptedField(Sequelize, key2);
+
+        const AnotherUser = sequelize.define('user', {
+            name: Sequelize.STRING,
+            another_encrypted: vault.vault('another_encrypted'),
+            private_2: vault.field('private_2'),
+            private_1: vault.field('private_1'),
+        });
+
+        const found = await AnotherUser.findById(user.id);
+        assert.equal(found.private_2, user.private_2);
+
+        // encrypted with key1 and different field originally
+        // and thus can't be recovered with key2
+        assert.equal(found.private_1, undefined);
+    });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,5 @@
+--reporter spec
+--check-leaks
+--bail
+--compilers js:babel-register
+--require babel-polyfill


### PR DESCRIPTION
The only breaking change this introduces to the API is that you must call `.vault()` before you call `.field()`  otherwise the fields won't know what the underlying encrypted vault name is. This is the simplest patch I could think of that adds this functionality without getting too crazy with other stuff. 