### PR TITLE
Added support for validations, allowNull and defaultValues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ var User = sequelize.define('user', {
 
     // encrypted virtual fields
     private_1: enc_fields.field('private_1'),
-    private_2: enc_fields.field('private_2')
+
+    // Optional second argument allows you
+    // to pass in a validation configuration
+    // as well as an optional return type
+    private_2: enc_fields.field('private_2', {
+      type: Sequelize.TEXT,
+      validate: {
+        isInt: true  
+      },
+      defaultValue: null
+    })
 })
 
 var user = User.build();

--- a/test/index.js
+++ b/test/index.js
@@ -59,13 +59,13 @@ describe('sequelize-encrypted', () => {
     });
 
     it('should support validation', async() => {
-      const VAULT = EncryptedField(Sequelize, key2);
+      const vault = EncryptedField(Sequelize, key2);
       const ValidUser = sequelize.define('validUser', {
           name: Sequelize.STRING,
-          encrypted: VAULT.vault('encrypted'),
+          encrypted: vault.vault('encrypted'),
 
           // encrypted virtual fields
-          private_1: VAULT.field('private_1', {
+          private_1: vault.field('private_1', {
             type: Sequelize.INTEGER,
             validate: {
               notEmpty: true
@@ -76,32 +76,32 @@ describe('sequelize-encrypted', () => {
       user.private_1 = '';
 
       const res = await user.validate();
-      assert.equal(res.message, "Validation error: Validation notEmpty failed");
+      assert.equal(res.message, 'Validation error: Validation notEmpty failed');
     });
 
     it('should support defaultValue', async() => {
-      const VAULT = EncryptedField(Sequelize, key2);
+      const vault = EncryptedField(Sequelize, key2);
       const ValidUser = sequelize.define('validUser', {
           name: Sequelize.STRING,
-          encrypted: VAULT.vault('encrypted'),
+          encrypted: vault.vault('encrypted'),
 
           // encrypted virtual fields
-          private_1: VAULT.field('private_1', {
-            defaultValue: "hello"
+          private_1: vault.field('private_1', {
+            defaultValue: 'hello'
           })
       });
       const user = ValidUser.build();
-      assert.equal(user.private_1, "hello");
+      assert.equal(user.private_1, 'hello');
     });
 
     it('should support allowNull', async() => {
-      const VAULT = EncryptedField(Sequelize, key2);
+      const vault = EncryptedField(Sequelize, key2);
       const ValidUser = sequelize.define('validUser', {
           name: Sequelize.STRING,
-          encrypted: VAULT.vault('encrypted'),
+          encrypted: vault.vault('encrypted'),
 
           // encrypted virtual fields
-          private_1: VAULT.field('private_1', {
+          private_1: vault.field('private_1', {
             allowNull: false
           })
       });

--- a/test/index.js
+++ b/test/index.js
@@ -58,4 +58,56 @@ describe('sequelize-encrypted', () => {
         assert.equal(found.private_1, undefined);
     });
 
+    it('should support validation', async() => {
+      const VAULT = EncryptedField(Sequelize, key2);
+      const ValidUser = sequelize.define('validUser', {
+          name: Sequelize.STRING,
+          encrypted: VAULT.vault('encrypted'),
+
+          // encrypted virtual fields
+          private_1: VAULT.field('private_1', {
+            type: Sequelize.INTEGER,
+            validate: {
+              notEmpty: true
+            }
+          })
+      });
+      const user = ValidUser.build();
+      user.private_1 = '';
+
+      const res = await user.validate();
+      assert.equal(res.message, "Validation error: Validation notEmpty failed");
+    });
+
+    it('should support defaultValue', async() => {
+      const VAULT = EncryptedField(Sequelize, key2);
+      const ValidUser = sequelize.define('validUser', {
+          name: Sequelize.STRING,
+          encrypted: VAULT.vault('encrypted'),
+
+          // encrypted virtual fields
+          private_1: VAULT.field('private_1', {
+            defaultValue: "hello"
+          })
+      });
+      const user = ValidUser.build();
+      assert.equal(user.private_1, "hello");
+    });
+
+    it('should support allowNull', async() => {
+      const VAULT = EncryptedField(Sequelize, key2);
+      const ValidUser = sequelize.define('validUser', {
+          name: Sequelize.STRING,
+          encrypted: VAULT.vault('encrypted'),
+
+          // encrypted virtual fields
+          private_1: VAULT.field('private_1', {
+            allowNull: false
+          })
+      });
+      const user = ValidUser.build();
+      const res = await user.validate();
+      assert.equal(res.message,'notNull Violation: private_1 cannot be null');
+    });
+
 });


### PR DESCRIPTION
Due to the git problems I was having with the previous PR, here is a new clean PR with passing tests. As a reminder of the contents of this PR:

---

@defunctzombie so I cleaned up the code and rebased off of master. So to recap, the main additions here are that you get all of the same configuration options are you would when creating a regular sequelize field:

``` javascript
    private_2: enc_fields.field('private_2', {
      type: Sequelize.TEXT,
      validate: {
        isInt: true  
      },
      allowNull: false,
      defaultValue: null
    })
```

If you pass in the "type", your field will be cast as that type using the built-in functionality of sequelize. You can pass in validation rules just like you would a regular field and you can also supply a default value. One of the issues I was having was when creating models where the field is not in the payload, the encrypted field was showing up like this:

```
{"encrypted": {"someField":"undefined"}}
```

So passing in the the default value, the getter on the virtual field returns your defaultValue if the value in the encrypted field is empty.

Finally, the ability to pass in the allowNull attr as you would a regular property.

I've also added tests for each of the above.
