### PR TITLE
Use Buffer.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function EncryptedField(Sequelize, key, opt) {
     }
 
     var self = this;
-    self.key = new Buffer(key, 'hex');
+    self.key = Buffer.from(key, 'hex');
     self.Sequelize = Sequelize;
 
     opt = opt || {};
@@ -32,7 +32,7 @@ EncryptedField.prototype.vault = function(name) {
                 return {};
             }
 
-            previous = new Buffer(previous);
+            previous = Buffer.from(previous);
 
             var iv = previous.slice(0, self._iv_length);
             var content = previous.slice(self._iv_length, previous.length);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-register": "6.9.0",
     "mocha": "2.0.1",
-    "pg": "6.0.1",
-    "sequelize": "3.23.4"
+    "sequelize": "3.23.4",
+    "sqlite3": "^3.1.4"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,10 @@ import assert from 'assert';
 import Sequelize from 'sequelize';
 import EncryptedField from '../';
 
-const sequelize = new Sequelize('postgres://postgres@db:5432/postgres');
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: ':memory:'
+});
 
 const key1 = 'a593e7f567d01031d153b5af6d9a25766b95926cff91c6be3438c7f7ac37230e';
 const key2 = 'a593e7f567d01031d153b5af6d9a25766b95926cff91c6be3438c7f7ac37230f';
@@ -23,7 +26,7 @@ describe('sequelize-encrypted', () => {
     });
 
     before('create models', async () => {
-        await User.sync({force: true});
+        await User.sync();
     });
 
     it('should save an encrypted field', async () => {


### PR DESCRIPTION
Due to `new Buffer(string[,encoding])` is deprecated we can use `Buffer.from(string[,encoding])` instead. 

For testing sqlite is easier I think. (Test suite setup the test db for us rather than doing extra steps like installing PostgreSQL)